### PR TITLE
Add ValueStorer interface and implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ Usage
       session.Save(r, w)
     }
 
+
+    ......
+    // you can also setup a MemCacheStore, which does not rely on the browser accepting cookies.
+    // this means, your client has to extract and send a configurable http Headerfield manually.
+    // e.g.
+
+    // set up your memcache client
+    memcacheClient := memcache.New("localhost:11211")
+    
+    // set up your session store relying on a http Headerfield: `X-CUSTOM-HEADER`
+    store := gsm.NewMemcacheStoreWithValueStorer(memcacheClient, &gsm.HeaderStorer{HeaderPrefix:"X-CUSTOM-HEADER"}, "session_prefix_", []byte("secret-key-goes-here"))
+    
+    // and the rest of it is the same as any other gorilla session handling:
+    // The client has to send the session information in the header-field: `X-CUSTOM-HEADER`
+    func MyHandler(w http.ResponseWriter, r *http.Request) {
+      session, _ := store.Get(r, "session-name")
+      session.Values["foo"] = "bar"
+      session.Values[42] = 43
+      session.Save(r, w)
+    }
+
 Storage Methods
 ---------------
 

--- a/gsm_test.go
+++ b/gsm_test.go
@@ -89,3 +89,86 @@ func TestMain(t *testing.T) {
 	doRun(StoreMethodJson, ":18203")
 
 }
+
+// TestMainHeaderStorer tests storing the secure sessionID in a configurable http HEADER field
+// and then fetching the session information via Memcache.
+func TestMainHeaderStorer(t *testing.T) {
+	headerName := "X-TEST-HEADER"
+
+	doRun := func(method StoreMethod, listenConfig string) {
+
+		headerStorer := &HeaderStorer{HeaderFieldName: headerName}
+		memcacheClient := memcache.New("localhost:11211")
+		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
+		sessionStore := NewMemcacheStoreWithValueStorer(memcacheClient, headerStorer, "TestMain_", []byte("example123"))
+		sessionStore.StoreMethod = StoreMethod(method)
+		sessionStore.Logging = 1
+
+		http.HandleFunc("/testHeaderStorer"+string(method), func(w http.ResponseWriter, r *http.Request) {
+			// fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+
+			session, _ := sessionStore.Get(r, "example")
+
+			storeval := r.FormValue("store")
+			if len(storeval) > 0 {
+				session.Values["thevalue"] = storeval
+			} else {
+				storeval, _ = session.Values["thevalue"].(string)
+			}
+
+			err := session.Save(r, w)
+			if err != nil {
+				fmt.Printf("Error while saving session: %v\n", err)
+			}
+
+			fmt.Fprintf(w, "%s", storeval)
+
+		})
+
+		// run the server
+		go http.ListenAndServe(listenConfig, nil)
+
+		// now do some tests as a client make sure things work as expected
+		httpClient := &http.Client{}
+
+		doReq := func(req *http.Request) (string, string, string) {
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				panic(err)
+			}
+			defer resp.Body.Close()
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				panic(err)
+
+			}
+
+			value := resp.Header.Get(headerName)
+			fmt.Printf("Got %s: %s\n", headerName, value)
+
+			return string(b), headerName, value
+		}
+
+		// the first request should return a headerKey and headerValue, which contain a securely encrypted sessionID.
+		// subsequent requests should sent this sessionID along so the server can fetch the session from the memcache store.
+		req, _ := http.NewRequest("GET", "http://localhost"+listenConfig+"/testHeaderStorer"+string(method)+"?store=blah", nil)
+		v, headerKey, headerValue := doReq(req)
+		if v != "blah" {
+			t.Fatalf("Expected v=blah but got v='%s'\n", v)
+		}
+
+		req, _ = http.NewRequest("GET", "http://localhost"+listenConfig+"/testHeaderStorer"+string(method), nil)
+		// sent header along with secure sessionID
+		req.Header.Add(headerKey, headerValue)
+		v, _, _ = doReq(req)
+		if v != "blah" {
+			t.Fatalf("Expected session to give us v=blah but got v='%s'\n", v)
+		}
+
+	}
+
+	doRun(StoreMethodSecureCookie, ":18201")
+	doRun(StoreMethodGob, ":18202")
+	doRun(StoreMethodJson, ":18203")
+
+}

--- a/gsmstub_test.go
+++ b/gsmstub_test.go
@@ -74,3 +74,72 @@ func TestStubMain(t *testing.T) {
 	}
 
 }
+
+func TestStubHeaderStorer(t *testing.T) {
+	headerName := "X-TEST-HEADER"
+	headerStorer := &HeaderStorer{HeaderFieldName: headerName}
+
+	sessionStore := NewDumbMemorySessionStoreWithValueStorer(headerStorer)
+
+	http.HandleFunc("/testdumbHeaderStorer", func(w http.ResponseWriter, r *http.Request) {
+		// fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+
+		session, _ := sessionStore.Get(r, "example")
+
+		storeval := r.FormValue("store")
+		if len(storeval) > 0 {
+			session.Values["thevalue"] = storeval
+		} else {
+			storeval, _ = session.Values["thevalue"].(string)
+		}
+
+		err := session.Save(r, w)
+		if err != nil {
+			fmt.Printf("Error while saving session: %v\n", err)
+		}
+
+		fmt.Fprintf(w, "%s", storeval)
+
+	})
+
+	// run the server
+	go http.ListenAndServe(":18210", nil)
+
+	// now do some tests as a client make sure things work as expected
+	httpClient := &http.Client{}
+
+	doReq := func(req *http.Request) (string, string, string) {
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			panic(err)
+		}
+		defer resp.Body.Close()
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			panic(err)
+
+		}
+
+		value := resp.Header.Get(headerName)
+		fmt.Printf("Got %s: %s\n", headerName, value)
+
+		return string(b), headerName, value
+	}
+
+	// the first request should return a headerKey and headerValue, which contain a securely encrypted sessionID.
+	// subsequent requests should sent this sessionID along so the server can fetch the session from the memcache store.
+	req, _ := http.NewRequest("GET", "http://localhost:18210/testdumbHeaderStorer?store=blah", nil)
+	v, headerKey, headerValue := doReq(req)
+	if v != "blah" {
+		t.Fatalf("Expected v=blah but got v='%s'\n", v)
+	}
+
+	req, _ = http.NewRequest("GET", "http://localhost:18210/testdumbHeaderStorer", nil)
+	// sent header along with secure sessionID
+	req.Header.Add(headerKey, headerValue)
+	v, _, _ = doReq(req)
+	if v != "blah" {
+		t.Fatalf("Expected session to give us v=blah but got v='%s'\n", v)
+	}
+
+}

--- a/valuestorer.go
+++ b/valuestorer.go
@@ -1,0 +1,127 @@
+package gsm
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+)
+
+var (
+	// ErrHeaderFieldNameEmpty is returned, if the HeaderFieldName, which should be used to store session information, is empty.
+	ErrHeaderFieldNameEmpty = errors.New("header fieldname empty")
+
+	// ErrValueNotFound is returned, if no value was found for a given sessionName.
+	ErrValueNotFound = errors.New("value not found")
+)
+
+// ValueStorer stores a value for a given name inside a http.Request.
+// The value is typically the encrypted sessionID, which can then be
+// fetched by a Gorialla sessions.Store implementation.
+type ValueStorer interface {
+	// GetValueForSessionName gets a value string using it's underlying ValueStorer implementation.
+	GetValueForSessionName(r *http.Request, name string) (string, error)
+
+	// SetValueForSessionName sets a value string using it's underlying ValueStorer implementation.
+	SetValueForSessionName(w http.ResponseWriter, name, value string, options *sessions.Options) error
+}
+
+// CookieStorer is a ValueStorer, which stores values inside an http.Cookie
+type CookieStorer struct{}
+
+// GetValueForSessionName gets a value string from an http.Cookie, which should be present in the http.Request.
+func (s *CookieStorer) GetValueForSessionName(r *http.Request, name string) (string, error) {
+	c, err := r.Cookie(name)
+	if err != nil {
+		return "", err
+	}
+	return c.Value, nil
+}
+
+// SetValueForSessionName sets a value string by creating a new http.Cookie and setting a `Set-Cookie` header
+func (s *CookieStorer) SetValueForSessionName(w http.ResponseWriter, name, value string, options *sessions.Options) error {
+	http.SetCookie(w, sessions.NewCookie(name, value, options))
+	return nil
+}
+
+// HeaderStorer is a ValueStorer, which stores values inside an http Header.
+// The key of the header contains can be configured using the `HeaderFieldName` variable.
+// The header value is a Base64 encoded JSON map, whereas the keys of the map are the sessionName.
+type HeaderStorer struct {
+	HeaderFieldName string
+}
+
+// GetValueForSessionName gets a value string from an http.Header.
+func (s *HeaderStorer) GetValueForSessionName(r *http.Request, name string) (string, error) {
+	// fetch header field from header.
+	headerBase64Encoded := r.Header.Get(s.HeaderFieldName)
+	if headerBase64Encoded == "" {
+		return "", ErrValueNotFound
+	}
+
+	// fetch value for name from JSON map.
+	headerMap, err := s.headerToMap(headerBase64Encoded)
+	if err != nil {
+		return "", err
+	}
+	value, exists := headerMap[name]
+	if !exists {
+		return "", ErrValueNotFound
+	}
+	return value, nil
+}
+
+// SetValueForSessionName sets a value string by creating a new http.Header using the header key given by the headerStorer.HeaderKey function.
+func (s *HeaderStorer) SetValueForSessionName(w http.ResponseWriter, name, value string, options *sessions.Options) error {
+	var newHeaderMap map[string]string
+
+	// try to fetch an existing headerMap to we can append our values
+	headerBase64Encoded := w.Header().Get(s.HeaderFieldName)
+	if headerBase64Encoded != "" {
+		currentHeaderMap, err := s.headerToMap(headerBase64Encoded)
+		if err != nil {
+			return err
+		}
+		// we found old values. Prepare newHeaderMap, so we can add/update values.
+		newHeaderMap = currentHeaderMap
+	} else {
+		// no header found. add a new one.
+		newHeaderMap = make(map[string]string)
+	}
+
+	// add/update value to map.
+	newHeaderMap[name] = value
+
+	// encode to base64 string
+	newHeaderEncoded, err := s.mapToHeader(newHeaderMap)
+	if err != nil {
+		return err
+	}
+	// add/replace current header
+	w.Header().Set(s.HeaderFieldName, newHeaderEncoded)
+	return nil
+}
+
+// headerToMap decodes a base64 encoded JSON map into a regular JSON map.
+func (s *HeaderStorer) headerToMap(headerBase64Encoded string) (map[string]string, error) {
+	headerJson, err := base64.StdEncoding.DecodeString(headerBase64Encoded)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(headerJson), &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// mapToHeader encoded a JSON map into a base64 encoded string.
+func (s *HeaderStorer) mapToHeader(headerMap map[string]string) (string, error) {
+	result, err := json.Marshal(headerMap)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(result), nil
+}


### PR DESCRIPTION
- This PR adds support to store the encrypted sessionID inside a http HeaderField, instead of a http.Cookie.
- The code is compatible with your implementation and falls back using the `Set-Cookie` header field.

Motivation:

If you are doing CORS, the `Set-Cookie` command does not work with all browsers, since some might block cookies from third-party webpages, or only allow cookies from third-party websites, once you have visited them.

To circumvent this problem but still be compatible with the Gorilla sessions package, this PR adds support to store the sessionID inside a configurable header field, given a `HeaderFieldName`.
This is done by introducing the interface `ValueStorer`. The implementation `CookieStorer` does the same as was done internally in your package. It sets the cookie with `http.SetCookie` and gets the cookie value via `r.Cookie`. The only value, which Gorilla stores in the Cookie was an encrypted sessionID:

snipped old code (c.Value gets decrypted and parsed into `sessions.ID`)

```
if c, errCookie := r.Cookie(name); errCookie == nil {
-       err = securecookie.DecodeMulti(name, c.Value, &session.ID, s.Codecs...)
```

Using ValueStorer this gets abstracted.

For example, you can use your code with the new `HeaderStorer` implementation, and set the headerfieldname to  `X-MY-HEADERFIELD`. Then you can add a new session with `name = MyNAME`.
Then the `HeaderStorer` will put the encrypted `sessionID` in the header-field with key: `X-MY-HEADERFIELD` whereas the value will be an base64 encoded `JSON` dictionary, where the keys are `session.Name()`

e.g.: `session.Name()` yields: "MyAuthSession", the value will be the encrypted sessionID from Gozilla:

``` json
{"MyAuthSession": "AAAAFFFFBBBBBBBBB........."}
```

This will be encoded once more using base64:

`eyJNeUF1dGhTZXNzaW9uIjogIkFBQUFGRkZGQkJCQkJCQkJCLi4uLi4uLi4uIn0K`

And put into the header:

`X-MY-HEADERFIELD: eyJNeUF1dGhTZXNzaW9uIjogIkFBQUFGRkZGQkJCQkJCQkJCLi4uLi4uLi4uIn0K`
