### PR TITLE
If session not found in Memcache, create a new one

### DIFF
--- a/gsm.go
+++ b/gsm.go
@@ -105,6 +105,11 @@ func (s *MemcacheStore) New(r *http.Request, name string) (*sessions.Session, er
 			err = s.load(session)
 			if err == nil {
 				session.IsNew = false
+			} else {
+				if err == memcache.ErrCacheMiss {
+					// If the session wasn't found in memcache, create a new one
+					err = s.save(session)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This happens when a user has a stored session cookie from a prior
run of memcached.  eg the memcached server/cluster has been restarted

When the user returns, their session cookie is successfully decoded
but the memcache value it refers to doesn't exist.