### PR TITLE
Add option to use binary memcache client for session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,54 +10,66 @@ The usual gorilla stuff:
 
     go get github.com/gorilla/sessions
 
-Plus Brad Fitz' memcache client:
+For an ASCII memcache client:
 
     go get github.com/bradfitz/gomemcache/memcache
+
+For a binary memcache client with SASL authentication:
+
+    go get github.com/memcachier/mc
 
 Usage
 -----
 
-    import (
-      "github.com/bradfitz/gomemcache/memcache"
-      gsm "github.com/bradleypeabody/gorilla-sessions-memcache"
-    )
+```go
+import (
+  "github.com/bradfitz/gomemcache/memcache"
+  // or
+  "github.com/memcachier/mc"
+  gsm "github.com/bradleypeabody/gorilla-sessions-memcache"
+)
 
-    ...
+...
 
-    // set up your memcache client
-    memcacheClient := memcache.New("localhost:11211")
-    
-    // set up your session store
-    store := gsm.NewMemcacheStore(memcacheClient, "session_prefix_", []byte("secret-key-goes-here"))
-    
-    // and the rest of it is the same as any other gorilla session handling:
-    func MyHandler(w http.ResponseWriter, r *http.Request) {
-      session, _ := store.Get(r, "session-name")
-      session.Values["foo"] = "bar"
-      session.Values[42] = 43
-      session.Save(r, w)
-    }
+// set up your memcache client
+memcacheClient := memcache.New("localhost:11211")
+// or
+memcacheClient := mc.NewMC("localhost:11211", "username", "password")
+
+// set up your session store
+store := gsm.NewMemcacheStore(memcacheClient, "session_prefix_", []byte("secret-key-goes-here"))
+
+// and the rest of it is the same as any other gorilla session handling:
+func MyHandler(w http.ResponseWriter, r *http.Request) {
+  session, _ := store.Get(r, "session-name")
+  session.Values["foo"] = "bar"
+  session.Values[42] = 43
+  session.Save(r, w)
+}
 
 
-    ......
-    // you can also setup a MemCacheStore, which does not rely on the browser accepting cookies.
-    // this means, your client has to extract and send a configurable http Headerfield manually.
-    // e.g.
+...
+// you can also setup a MemCacheStore, which does not rely on the browser accepting cookies.
+// this means, your client has to extract and send a configurable http Headerfield manually.
+// e.g.
 
-    // set up your memcache client
-    memcacheClient := memcache.New("localhost:11211")
-    
-    // set up your session store relying on a http Headerfield: `X-CUSTOM-HEADER`
-    store := gsm.NewMemcacheStoreWithValueStorer(memcacheClient, &gsm.HeaderStorer{HeaderPrefix:"X-CUSTOM-HEADER"}, "session_prefix_", []byte("secret-key-goes-here"))
-    
-    // and the rest of it is the same as any other gorilla session handling:
-    // The client has to send the session information in the header-field: `X-CUSTOM-HEADER`
-    func MyHandler(w http.ResponseWriter, r *http.Request) {
-      session, _ := store.Get(r, "session-name")
-      session.Values["foo"] = "bar"
-      session.Values[42] = 43
-      session.Save(r, w)
-    }
+// set up your memcache client
+memcacheClient := memcache.New("localhost:11211")
+// or
+memcacheClient := mc.NewMC("localhost:11211", "username", "password")
+
+// set up your session store relying on a http Headerfield: `X-CUSTOM-HEADER`
+store := gsm.NewMemcacheStoreWithValueStorer(memcacheClient, &gsm.HeaderStorer{HeaderPrefix:"X-CUSTOM-HEADER"}, "session_prefix_", []byte("secret-key-goes-here"))
+
+// and the rest of it is the same as any other gorilla session handling:
+// The client has to send the session information in the header-field: `X-CUSTOM-HEADER`
+func MyHandler(w http.ResponseWriter, r *http.Request) {
+  session, _ := store.Get(r, "session-name")
+  session.Values["foo"] = "bar"
+  session.Values[42] = 43
+  session.Save(r, w)
+}
+```
 
 Storage Methods
 ---------------
@@ -72,27 +84,31 @@ use them by setting the StoreMethod field.
 * Json - uses the Json Marshaller.  Result is human readable, slower but still
   pretty fast.  Be careful - it will munch your data into stuff that works
   with JSON, and the keys must be strings.  Example: you put in an int64 value
-  and you'll get back a float64. 
+  and you'll get back a float64.
 
 Example:
 
-    store := gsm.NewMemcacheStore(memcacheClient, "session_prefix_", []byte("..."))
-    // do one of these:
-    store.StoreMethod = gsm.StoreMethodSecureCookie // default, more secure
-    store.StoreMethod = gsm.StoreMethodGob // faster
-    store.StoreMethod = gsm.StoreMethodJson // human readable
-    							// (but watch out, it munches your types
-    							// to JSON compatible stuff)
+```go
+store := gsm.NewMemcacheStore(memcacheClient, "session_prefix_", []byte("..."))
+// do one of these:
+store.StoreMethod = gsm.StoreMethodSecureCookie // default, more secure
+store.StoreMethod = gsm.StoreMethodGob // faster
+store.StoreMethod = gsm.StoreMethodJson // human readable
+							// (but watch out, it munches your types
+							// to JSON compatible stuff)
+```
 
 Logging
 -------
 
 Logging is available by setting the Logging field to > 0 after making your MemcacheStore.
 
-    store := gsm.NewMemcacheStore(memcacheClient, "session_prefix_", []byte("..."))
-    store.Logging = 1
+```go
+store := gsm.NewMemcacheStore(memcacheClient, "session_prefix_", []byte("..."))
+store.Logging = 1
+```
 
-That will output (using log.Printf) data about each session read/written from/to memcache.
+That will output (using `log.Printf`) data about each session read/written from/to memcache.
 Useful for debugging
 
 Things to Know

--- a/gsm.go
+++ b/gsm.go
@@ -22,7 +22,7 @@ import (
 // an optional prefix for the keys we store.
 // A ValueStorer is used to store an encrypted sessionID. The encrypted sessionID is used to access
 // memcache and get the session values.
-func NewMemcacheStoreWithValueStorer(client Memcacher, valueStorer ValueStorer, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+func NewMemcacherStoreWithValueStorer(client Memcacher, valueStorer ValueStorer, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
 
 	if client == nil {
 		panic("Cannot have nil memcache client")
@@ -45,19 +45,29 @@ func NewMemcacheStoreWithValueStorer(client Memcacher, valueStorer ValueStorer, 
 	}
 }
 
-// NewMemcacheStore returns a new MemcacheStore.
+// NewMemcacherStore returns a new MemcacheStore.
 // You need to provide the memcache client that
 // implements the Memcacher interface and
 // an optional prefix for the keys we store
-func NewMemcacheStore(client Memcacher, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
-	return NewMemcacheStoreWithValueStorer(client, &CookieStorer{}, keyPrefix, keyPairs...)
+func NewMemcacherStore(client Memcacher, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+	return NewMemcacherStoreWithValueStorer(client, &CookieStorer{}, keyPrefix, keyPairs...)
 }
 
-// NewGomemcacheStore returns a new MemcacheStore for the
+// NewMemcacheStoreWithValueStorer returns a new MemcacheStore backed by a ValueStorer.
+// You need to provide the gomemcache client
+// (github.com/bradfitz/gomemcache/memcache) and
+// an optional prefix for the keys we store.
+// A ValueStorer is used to store an encrypted sessionID. The encrypted sessionID is used to access
+// memcache and get the session values.
+func NewMemcacheStoreWithValueStorer(client *memcache.Client, valueStorer ValueStorer, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+	return NewMemcacherStoreWithValueStorer(NewGoMemcacher(client), valueStorer, keyPrefix, keyPairs...)
+}
+
+// NewMemcacheStore returns a new MemcacheStore for the
 // gomemcache client (github.com/bradfitz/gomemcache/memcache).
 // You also need to provider an optional prefix for the keys we store.
-func NewGomemcacheStore(client *memcache.Client, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
-	return NewMemcacheStore(NewGoMemcacher(client), keyPrefix, keyPairs...)
+func NewMemcacheStore(client *memcache.Client, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+	return NewMemcacherStore(NewGoMemcacher(client), keyPrefix, keyPairs...)
 }
 
 type StoreMethod string

--- a/gsm.go
+++ b/gsm.go
@@ -11,18 +11,18 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
-	"github.com/memcachier/mc"
 	"log"
 	"net/http"
 	"strings"
 )
 
 // NewMemcacheStoreWithValueStorer returns a new MemcacheStore backed by a ValueStorer.
-// You need to provide the memcache client (github.com/bradfitz/gomemcache/memcache) and
+// You need to provide the memcache client that
+// implements the Memcacher interface and
 // an optional prefix for the keys we store.
 // A ValueStorer is used to store an encrypted sessionID. The encrypted sessionID is used to access
 // memcache and get the session values.
-func NewMemcacheStoreWithValueStorer(client *memcache.Client, valueStorer ValueStorer, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+func NewMemcacheStoreWithValueStorer(client Memcacher, valueStorer ValueStorer, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
 
 	if client == nil {
 		panic("Cannot have nil memcache client")
@@ -46,47 +46,18 @@ func NewMemcacheStoreWithValueStorer(client *memcache.Client, valueStorer ValueS
 }
 
 // NewMemcacheStore returns a new MemcacheStore.
-// You need to provide the memcache client
-// (github.com/bradfitz/gomemcache/memcache) and
+// You need to provide the memcache client that
+// implements the Memcacher interface and
 // an optional prefix for the keys we store
-func NewMemcacheStore(client *memcache.Client, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+func NewMemcacheStore(client Memcacher, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
 	return NewMemcacheStoreWithValueStorer(client, &CookieStorer{}, keyPrefix, keyPairs...)
 }
 
-// NewBinaryMemcacheStoreWithValueStorer returns a new MemcacheStore backed by a ValueStorer.
-// You need to provide the binary memcache client (github.com/memcachier/mc) and
-// an optional prefix for the keys we store.
-// A ValueStorer is used to store an encrypted sessionID. The encrypted sessionID is used to access
-// memcache and get the session values.
-func NewBinaryMemcacheStoreWithValueStorer(client *mc.Client, valueStorer ValueStorer, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
-
-	if client == nil {
-		panic("Cannot have nil memcache client")
-	}
-
-	if valueStorer == nil {
-		panic("Cannot have nil ValueStorer")
-	}
-
-	return &MemcacheStore{
-		Codecs: securecookie.CodecsFromPairs(keyPairs...),
-		Options: &sessions.Options{
-			Path:   "/",
-			MaxAge: 86400 * 30,
-		},
-		KeyPrefix:    keyPrefix,
-		BinaryClient: client,
-		StoreMethod:  StoreMethodSecureCookie,
-		ValueStorer:  valueStorer,
-	}
-}
-
-// NewBinarMemcacheStore returns a new MemcacheStore.
-// You need to provide the binary memcache client
-// (github.com/memcachier/mc) and
-// an optional prefix for the keys we store
-func NewBinaryMemcacheStore(client *mc.Client, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
-	return NewBinaryMemcacheStoreWithValueStorer(client, &CookieStorer{}, keyPrefix, keyPairs...)
+// NewGomemcacheStore returns a new MemcacheStore for the
+// gomemcache client (github.com/bradfitz/gomemcache/memcache).
+// You also need to provider an optional prefix for the keys we store.
+func NewGomemcacheStore(client *memcache.Client, keyPrefix string, keyPairs ...[]byte) *MemcacheStore {
+	return NewMemcacheStore(NewGoMemcacher(client), keyPrefix, keyPairs...)
 }
 
 type StoreMethod string
@@ -103,8 +74,7 @@ const (
 type MemcacheStore struct {
 	Codecs       []securecookie.Codec
 	Options      *sessions.Options // default configuration
-	Client       *memcache.Client
-	BinaryClient *mc.Client
+	Client       Memcacher
 	KeyPrefix    string
 	Logging      int // set to > 0 to enable logging (using log.Printf)
 	StoreMethod  StoreMethod
@@ -192,11 +162,7 @@ func (s *MemcacheStore) save(session *sessions.Session) error {
 			return err
 		}
 
-		if s.Client != nil {
-			err = s.Client.Set(&memcache.Item{Key: key, Value: []byte(encoded), Expiration: int32(session.Options.MaxAge)})
-		} else {
-			_, err = s.BinaryClient.Set(key, encoded, 0, uint32(session.Options.MaxAge), 0)
-		}
+		_, err = s.Client.Set(key, encoded, 0, uint32(session.Options.MaxAge), 0)
 		if s.Logging > 0 {
 			log.Printf("gorilla-sessions-memcache: set (method: securecookie, session name: %v, memcache key: %v, memcache value: %v, error: %v)", session.Name(), key, encoded, err)
 		}
@@ -219,11 +185,7 @@ func (s *MemcacheStore) save(session *sessions.Session) error {
 		}
 		bufbytes := buf.Bytes()
 
-		if s.Client != nil {
-			err = s.Client.Set(&memcache.Item{Key: key, Value: bufbytes, Expiration: int32(session.Options.MaxAge)})
-		} else {
-			_, err = s.BinaryClient.Set(key, string(bufbytes), 0, uint32(session.Options.MaxAge), 0)
-		}
+		_, err = s.Client.Set(key, string(bufbytes), 0, uint32(session.Options.MaxAge), 0)
 		if s.Logging > 0 {
 			log.Printf("gorilla-sessions-memcache: set (method: gob, session name: %v, memcache key: %v, memcache value len: %v, error: %v)", session.Name(), key, len(bufbytes), err)
 		}
@@ -254,11 +216,7 @@ func (s *MemcacheStore) save(session *sessions.Session) error {
 			return err
 		}
 
-		if s.Client != nil {
-			err = s.Client.Set(&memcache.Item{Key: key, Value: bufbytes, Expiration: int32(session.Options.MaxAge)})
-		} else {
-			_, err = s.BinaryClient.Set(key, string(bufbytes), 0, uint32(session.Options.MaxAge), 0)
-		}
+		_, err = s.Client.Set(key, string(bufbytes), 0, uint32(session.Options.MaxAge), 0)
 		if s.Logging > 0 {
 			log.Printf("gorilla-sessions-memcache: set (method: json, session name: %v, memcache key: %v, memcache value: %v, error: %v)", session.Name(), key, string(bufbytes), err)
 		}
@@ -281,23 +239,12 @@ func (s *MemcacheStore) load(session *sessions.Session) error {
 
 	key := s.KeyPrefix + session.ID
 
-	var err error
-	var val string
-	var valBytes []byte
-	if s.Client != nil {
-		var it *memcache.Item
-		it, err = s.Client.Get(key)
-		valBytes = it.Value
-		val = string(valBytes)
-	} else {
-		val, _, _, err = s.BinaryClient.Get(key)
-		valBytes = []byte(val)
-	}
+	val, _, _, err := s.Client.Get(key)
 	if s.Logging > 0 {
 		if s.StoreMethod == StoreMethodJson {
 			log.Printf("gorilla-sessions-memcache: get (method: %s, session name: %v, memcache key: %v, memcache value: %v, error: %v)", s.StoreMethod, session.Name(), key, val, err)
 		} else {
-			log.Printf("gorilla-sessions-memcache: get (method: %s, session name: %v, memcache key: %v, memcache value len: %v, error: %v)", s.StoreMethod, session.Name(), key, len(valBytes), err)
+			log.Printf("gorilla-sessions-memcache: get (method: %s, session name: %v, memcache key: %v, memcache value len: %v, error: %v)", s.StoreMethod, session.Name(), key, len(val), err)
 		}
 	}
 	if err != nil {
@@ -319,7 +266,7 @@ func (s *MemcacheStore) load(session *sessions.Session) error {
 
 	case StoreMethodGob:
 
-		buf := bytes.NewBuffer(valBytes)
+		buf := bytes.NewBuffer([]byte(val))
 		dec := gob.NewDecoder(buf)
 
 		err = dec.Decode(&session.Values)
@@ -334,7 +281,7 @@ func (s *MemcacheStore) load(session *sessions.Session) error {
 
 		vals := make(map[string]interface{})
 
-		err := json.Unmarshal(valBytes, &vals)
+		err := json.Unmarshal([]byte(val), &vals)
 		if err != nil {
 			if s.Logging > 0 {
 				log.Printf("gorilla-sessions-memcache: get (method: json, decoding error: %v)", err)

--- a/gsm_test.go
+++ b/gsm_test.go
@@ -18,7 +18,7 @@ func TestMainGomemcache(t *testing.T) {
 
 		memcacheClient := memcache.New("localhost:11211")
 		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
-		sessionStore := NewGomemcacheStore(memcacheClient, "TestMain_", []byte("example123"))
+		sessionStore := NewMemcacheStore(memcacheClient, "TestMain_", []byte("example123"))
 		sessionStore.StoreMethod = StoreMethod(method)
 		sessionStore.Logging = 1
 
@@ -98,7 +98,7 @@ func TestMainMc(t *testing.T) {
 		memcacheClient := mc.NewMC("localhost:11211", "", "")
 		defer memcacheClient.Quit()
 		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
-		sessionStore := NewMemcacheStore(memcacheClient, "TestMainBinray_", []byte("example123"))
+		sessionStore := NewMemcacherStore(memcacheClient, "TestMainBinray_", []byte("example123"))
 		sessionStore.StoreMethod = StoreMethod(method)
 		sessionStore.Logging = 1
 
@@ -181,7 +181,7 @@ func TestMainHeaderStorer(t *testing.T) {
 		headerStorer := &HeaderStorer{HeaderFieldName: headerName}
 		memcacheClient := memcache.New("localhost:11211")
 		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
-		sessionStore := NewMemcacheStoreWithValueStorer(NewGoMemcacher(memcacheClient), headerStorer, "TestMain_", []byte("example123"))
+		sessionStore := NewMemcacheStoreWithValueStorer(memcacheClient, headerStorer, "TestMain_", []byte("example123"))
 		sessionStore.StoreMethod = StoreMethod(method)
 		sessionStore.Logging = 1
 

--- a/gsm_test.go
+++ b/gsm_test.go
@@ -3,6 +3,7 @@ package gsm
 import (
 	"fmt"
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/memcachier/mc"
 	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
@@ -78,6 +79,86 @@ func TestMain(t *testing.T) {
 		}
 
 		v = doReq("http://localhost" + listenConfig + "/test" + string(method))
+		if v != "blah" {
+			t.Fatalf("Expected session to give us v=blah but got v='%s'\n", v)
+		}
+
+	}
+
+	doRun(StoreMethodSecureCookie, ":18201")
+	doRun(StoreMethodGob, ":18202")
+	doRun(StoreMethodJson, ":18203")
+
+}
+
+func TestMainBinary(t *testing.T) {
+
+	doRun := func(method StoreMethod, listenConfig string) {
+
+		memcacheClient := mc.NewMC("localhost:11211", "", "")
+		defer memcacheClient.Quit()
+		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
+		sessionStore := NewBinaryMemcacheStore(memcacheClient, "TestMainBinray_", []byte("example123"))
+		sessionStore.StoreMethod = StoreMethod(method)
+		sessionStore.Logging = 1
+
+		http.HandleFunc("/testBinray"+string(method), func(w http.ResponseWriter, r *http.Request) {
+			// fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+
+			session, _ := sessionStore.Get(r, "example")
+
+			storeval := r.FormValue("store")
+			if len(storeval) > 0 {
+				session.Values["thevalue"] = storeval
+			} else {
+				storeval, _ = session.Values["thevalue"].(string)
+			}
+
+			err := session.Save(r, w)
+			if err != nil {
+				fmt.Printf("Error while saving session: %v\n", err)
+			}
+
+			fmt.Fprintf(w, "%s", storeval)
+
+		})
+
+		// run the server
+		go http.ListenAndServe(listenConfig, nil)
+
+		// now do some tests as a client make sure things work as expected
+
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			panic(err)
+		}
+		httpClient := &http.Client{
+			Jar: jar,
+		}
+
+		doReq := func(u string) string {
+			resp, err := httpClient.Get(u)
+			if err != nil {
+				panic(err)
+			}
+			defer resp.Body.Close()
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				panic(err)
+
+			}
+
+			fmt.Printf("Got Set-Cookie: %s\n", resp.Header.Get("Set-Cookie"))
+
+			return string(b)
+		}
+
+		v := doReq("http://localhost" + listenConfig + "/testBinray" + string(method) + "?store=blah")
+		if v != "blah" {
+			t.Fatalf("Expected v=blah but got v='%s'\n", v)
+		}
+
+		v = doReq("http://localhost" + listenConfig + "/testBinray" + string(method))
 		if v != "blah" {
 			t.Fatalf("Expected session to give us v=blah but got v='%s'\n", v)
 		}

--- a/gsm_test.go
+++ b/gsm_test.go
@@ -12,13 +12,13 @@ import (
 
 // FIXME: need unit tests for the different StoreMethods
 
-func TestMain(t *testing.T) {
+func TestMainGomemcache(t *testing.T) {
 
 	doRun := func(method StoreMethod, listenConfig string) {
 
 		memcacheClient := memcache.New("localhost:11211")
 		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
-		sessionStore := NewMemcacheStore(memcacheClient, "TestMain_", []byte("example123"))
+		sessionStore := NewGomemcacheStore(memcacheClient, "TestMain_", []byte("example123"))
 		sessionStore.StoreMethod = StoreMethod(method)
 		sessionStore.Logging = 1
 
@@ -91,14 +91,14 @@ func TestMain(t *testing.T) {
 
 }
 
-func TestMainBinary(t *testing.T) {
+func TestMainMc(t *testing.T) {
 
 	doRun := func(method StoreMethod, listenConfig string) {
 
 		memcacheClient := mc.NewMC("localhost:11211", "", "")
 		defer memcacheClient.Quit()
 		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
-		sessionStore := NewBinaryMemcacheStore(memcacheClient, "TestMainBinray_", []byte("example123"))
+		sessionStore := NewMemcacheStore(memcacheClient, "TestMainBinray_", []byte("example123"))
 		sessionStore.StoreMethod = StoreMethod(method)
 		sessionStore.Logging = 1
 
@@ -181,7 +181,7 @@ func TestMainHeaderStorer(t *testing.T) {
 		headerStorer := &HeaderStorer{HeaderFieldName: headerName}
 		memcacheClient := memcache.New("localhost:11211")
 		// fmt.Printf("memcacheClient = %v\n", memcacheClient)
-		sessionStore := NewMemcacheStoreWithValueStorer(memcacheClient, headerStorer, "TestMain_", []byte("example123"))
+		sessionStore := NewMemcacheStoreWithValueStorer(NewGoMemcacher(memcacheClient), headerStorer, "TestMain_", []byte("example123"))
 		sessionStore.StoreMethod = StoreMethod(method)
 		sessionStore.Logging = 1
 

--- a/memcacher_interface.go
+++ b/memcacher_interface.go
@@ -1,0 +1,38 @@
+package gsm
+
+import (
+	"github.com/bradfitz/gomemcache/memcache"
+)
+
+// Memcacher is the interface gsm uses to interact with the memcache client
+type Memcacher interface {
+	Get(key string) (val string, flags uint32, cas uint64, err error)
+	Set(key, val string, flags, exp uint32, ocas uint64) (cas uint64, err error)
+}
+
+
+// GoMemcacher is a wrapper to the gomemcache client that implements the
+// Memcacher interface
+type GoMemcacher struct {
+  client *memcache.Client
+}
+
+// NewGoMemcacher returns a wrapped gomemcache client that implements the
+// Memcacher interface
+func NewGoMemcacher(c *memcache.Client) *GoMemcacher {
+	if c == nil {
+		panic("Cannot have nil memcache client")
+	}
+	return &GoMemcacher{client: c}
+}
+
+func (gm *GoMemcacher) Get(key string) (val string, flags uint32, cas uint64, err error) {
+	it, err := gm.client.Get(key)
+  return string(it.Value), it.Flags, 0, err
+}
+
+
+func (gm *GoMemcacher) Set(key, val string, flags, exp uint32, ocas uint64) (cas uint64, err error) {
+	err = gm.client.Set(&memcache.Item{Key: key, Value: []byte(val), Expiration: int32(exp), Flags: flags})
+	return ocas, err
+}


### PR DESCRIPTION
This changes allows users to use gorilla-sessions-memcache with cloud providers that require SASL authentication to connect to memcache.

Also: added go highlighting to code blocks in README.